### PR TITLE
Podium implementation for game end

### DIFF
--- a/client/src/app.ts
+++ b/client/src/app.ts
@@ -105,6 +105,7 @@ socketService.setTransitionHandler((gameState: GameState) => {
             break;
         case 'POSTGAME':
             showPage('gameRoom');
+            (gameRoomLayer as any).updateTimer('POSTGAME', 0);
             break;
         default:
             console.warn('Unknown game state:', gameState);

--- a/client/src/app.ts
+++ b/client/src/app.ts
@@ -106,6 +106,7 @@ socketService.setTransitionHandler((gameState: GameState) => {
         case 'POSTGAME':
             showPage('gameRoom');
             (gameRoomLayer as any).updateTimer('POSTGAME', 0);
+            (gameRoomLayer as any).updateLeaderboard((gameRoomLayer as any).leaderboard);
             break;
         default:
             console.warn('Unknown game state:', gameState);

--- a/client/src/app.ts
+++ b/client/src/app.ts
@@ -106,7 +106,6 @@ socketService.setTransitionHandler((gameState: GameState) => {
         case 'POSTGAME':
             showPage('gameRoom');
             (gameRoomLayer as any).updateTimer('POSTGAME', 0);
-            (gameRoomLayer as any).updateLeaderboard((gameRoomLayer as any).leaderboard);
             break;
         default:
             console.warn('Unknown game state:', gameState);

--- a/client/src/pages/GameRoom.ts
+++ b/client/src/pages/GameRoom.ts
@@ -219,8 +219,11 @@ export function createGameRoom(stage: Konva.Stage, onLeaveGame: () => void): Kon
         });
         leaderboardGroup.add(title);
 
+        // Decide which players to render. On the final screen, only show top 3.
+        const displayedPlayers = isFinalScreen ? leaderboard.slice(0, 3) : leaderboard;
+
         // Render each player
-        leaderboard.forEach((player, index) => {
+        displayedPlayers.forEach((player, index) => {
             const yPos = 70 + (index * 30);
 
             const isWinner =

--- a/client/src/pages/GameRoom.ts
+++ b/client/src/pages/GameRoom.ts
@@ -44,32 +44,43 @@ export function createGameRoom(stage: Konva.Stage, onLeaveGame: () => void): Kon
 
         currentGameState = gameState;
 
-        if (gameState === 'PREGAME') {
-            message = `Game starts in: ${time}s`;
-        } else if (gameState === 'BEFORE_MINIGAME') {
-            message = `Next minigame in: ${time}s`;
-        } else if (gameState === 'POSTGAME') {
+        if (gameState === 'POSTGAME') {
+            // Change 'Game Over' timer color to gold, hide leaderboard, render podium
             message = `Game Over!`;
-
+            timerbox.fill('#ffd700');
+            leaderboardGroup.hide();
+            renderPodium();
         } else {
-            message = `Time: ${time}s`;
+            if (gameState === 'PREGAME') {
+                message = `Game starts in: ${time}s`;
+            } else if (gameState === 'BEFORE_MINIGAME') {
+                message = `Next minigame in: ${time}s`;
+            } else {
+                message = `Time: ${time}s`;
+            }
+
+            if (podiumGroup) {
+                podiumGroup.destroy(); 
+                podiumGroup = null;
+            }
+            timerbox.fill('white');
+            leaderboardGroup.show();
+            
         }
 
         timerText.text(message);
-
-        if (gameState === 'POSTGAME') {
-            timerbox.fill('#ffd700');
-        } else {
-            timerbox.fill('white');
-        }
-
         layer.draw();
     }
+
+    // Store latest leaderboard for access and modification during POSTGAME
+    let latestLeaderboard: Leaderboard = [];
+    let podiumGroup: Konva.Group | null = null;
 
     // Expose public method to update leaderboard (called by app.ts)
     (layer as any).updateLeaderboard = (leaderboard: Leaderboard) => {
         console.log('GameRoom: Updating leaderboard', leaderboard);
-        renderLeaderboard(leaderboard);
+        latestLeaderboard = leaderboard;
+        renderLeaderboard(latestLeaderboard);
     };
 
     // Expose public method to update timer (called by app.ts)
@@ -220,11 +231,8 @@ export function createGameRoom(stage: Konva.Stage, onLeaveGame: () => void): Kon
         });
         leaderboardGroup.add(title);
 
-        // Decide which players to render. On the final screen, only show top 3.
-        const displayedPlayers = isFinalScreen ? leaderboard.slice(0, 3) : leaderboard;
-
         // Render each player
-        displayedPlayers.forEach((player, index) => {
+        leaderboard.forEach((player, index) => {
             const yPos = 70 + (index * 30);
 
             const isWinner =
@@ -244,6 +252,110 @@ export function createGameRoom(stage: Konva.Stage, onLeaveGame: () => void): Kon
 
         layer.draw();
     }
+
+    function renderPodium() {
+        if (currentGameState !== 'POSTGAME') return;
+        
+        if (podiumGroup) {
+            podiumGroup.destroy(); 
+            podiumGroup = null;
+        }
+
+        podiumGroup = new Konva.Group();
+        
+
+        const podiumWidth = 200;
+        const podiumSpacing = 10;
+        const stageHeight = stage.height();
+        const stageWidth = stage.width();
+        
+        const totalWidth = (podiumWidth * 3) + (podiumSpacing * 2);
+        const podiumX = (stageWidth - totalWidth) / 2;
+        const podiumY = stageHeight * 0.8;
+
+        // Background
+        podiumGroup.add(new Konva.Rect({
+            x: podiumX - 20,
+            y: podiumY - stageHeight * 0.5 - 50,
+            width: totalWidth + 40,
+            height: stageHeight * 0.5 + 90,
+            fill: 'rgba(0, 0, 0, 0.4)',
+            cornerRadius: 10,
+        }));
+
+        // Podium configurations (order: 3rd, 1st, 2nd for left-to-right positioning)
+        const podiums = [
+            {
+                place: 2, // 3rd place
+                height: 0.2,
+                fill: '#cd7f32ff',
+                textShadow: 'black',
+            },
+            {
+                place: 0, // 1st place
+                height: 0.5,
+                fill: '#ffbf00ff',
+                textShadow: '#d19900ff',
+            },
+            {
+                place: 1, // 2nd place
+                height: 0.3,
+                fill: 'silver',
+                textShadow: 'black',
+            },
+        ];
+
+        // Create each podium
+        podiums.forEach(({ place, height, fill, textShadow }, index) => {
+            if (podiumGroup === null) return; // TypeScript null check, technically unnecessary but VSCode complains otherwise
+            const leaderboardEntry = latestLeaderboard[place];
+            
+            const xPos = podiumX + (podiumWidth + podiumSpacing) * index;
+            const podiumHeight = stageHeight * height;
+            const yPos = podiumY - podiumHeight;
+
+            // Podium rectangle (always render)
+            podiumGroup.add(new Konva.Rect({
+                x: xPos,
+                y: yPos,
+                width: podiumWidth,
+                height: podiumHeight,
+                fill: fill,
+                stroke: 'black',
+                strokeWidth: 2,
+            }));
+
+            // Only add text if player exists
+            if (leaderboardEntry) {
+                // Player name
+                podiumGroup.add(new Konva.Text({
+                    x: xPos,
+                    y: yPos - 35,
+                    width: podiumWidth,
+                    text: leaderboardEntry.username,
+                    fontSize: 30,
+                    fontStyle: 'bold',
+                    shadowColor: textShadow,
+                    shadowBlur: place === 0 ? 10 : 16,
+                    fill: place === 0 ? '#fffcf6ff' : (leaderboardEntry.active ? 'white' : '#f49a9aff'),
+                    align: 'center',
+                }));
+
+                // Score details
+                podiumGroup.add(new Konva.Text({
+                    x: xPos,
+                    y: yPos + 15,
+                    width: podiumWidth,
+                    text: `Total: ${leaderboardEntry.total_score} pts\n100M Dash: ${leaderboardEntry['100m_score']}\nMini: ${leaderboardEntry.minigame1_score}`,
+                    fontSize: 24,
+                    fill: 'white',
+                    align: 'center',
+                }));
+            }
+        });
+
+        layer.add(podiumGroup);
+    }            
 
     // Initial render with empty leaderboard
     renderLeaderboard([]);

--- a/client/src/pages/GameRoom.ts
+++ b/client/src/pages/GameRoom.ts
@@ -42,7 +42,7 @@ export function createGameRoom(stage: Konva.Stage, onLeaveGame: () => void): Kon
     function updateTimer(gameState: GameState, time: number): void {
         let message = '';
 
-         currentGameState = gameState;
+        currentGameState = gameState;
 
         if (gameState === 'PREGAME') {
             message = `Game starts in: ${time}s`;
@@ -50,6 +50,7 @@ export function createGameRoom(stage: Konva.Stage, onLeaveGame: () => void): Kon
             message = `Next minigame in: ${time}s`;
         } else if (gameState === 'POSTGAME') {
             message = `Game Over!`;
+
         } else {
             message = `Time: ${time}s`;
         }


### PR DESCRIPTION
Changes made:

app.ts :
- transition handler now emits the "POSTGAME" game state change when the game is over.

GameRoom.ts :
- Client side now stores a local copy of the leaderboard which updates on each updateLeaderboard call (for use in POSTGAME state)
- Timer box and text now correctly displays "Game Over" in a gold box when game ends
- Game room / leaderboard screen now displays a 3-person podium when game ends. 1st place is highlighted with gold glow, inactive players are highlighted in red, all other players displayed in white. Display also shows respective point totals. 

Example of updated end screen attached below:
<img width="401" height="297" alt="Screenshot 2025-12-02 at 12 26 19 PM" src="https://github.com/user-attachments/assets/41091a5d-4ebc-4fb5-a0ac-1d844456c357" />